### PR TITLE
chore: upgrade create-github-app-token to v3 in action-usage-sbom.yml

### DIFF
--- a/.github/workflows/action-usage-sbom.yml
+++ b/.github/workflows/action-usage-sbom.yml
@@ -30,10 +30,10 @@ jobs:
           repository: joshjohanning/github-misc-scripts
           path: github-misc-scripts
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: run actions export -- count-by-action
@@ -99,10 +99,10 @@ jobs:
           repository: joshjohanning/github-misc-scripts
           path: github-misc-scripts
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: run actions export -- count-by-version


### PR DESCRIPTION
## Summary

Upgrades remaining `actions/create-github-app-token` usage in `action-usage-sbom.yml` from `@v2` to `@v3` and migrates from `app-id` to `client-id`.

(The other workflow file was already updated in PR #18.)

### Changes
- ⬆️ Updated `actions/create-github-app-token` to `@v3`
- 🔄 Renamed input `app-id` → `client-id`
- 🔄 Updated variable reference from `APP_ID` → `APP_CLIENT_ID`